### PR TITLE
Stores transaction regardless of session presence

### DIFF
--- a/co2ok-plugin.php
+++ b/co2ok-plugin.php
@@ -373,11 +373,15 @@ if ( !class_exists( 'co2ok_plugin_woocommerce\Co2ok_Plugin' ) ) :
         global $woocommerce;
         switch ($new_status) {
             case "processing":
-                if ($woocommerce->session->co2ok == 1) {
+                $order = wc_get_order($order_id);
+                $fees = $order->get_fees();
+
+                foreach ($fees as $fee) {
+                if ($fee->get_name() == __( 'CO2 compensation (Inc. VAT)', 'co2ok-for-woocommerce' )) {
                     // The user did opt for co2 compensation
                     $this->co2ok_storeTransaction($order_id);
+                    break;
                 }
-                break;
 
             case "refunded":
             case "cancelled":


### PR DESCRIPTION
Bij bv cheque betalingen gaat de order status eerst naar on hold. Als de webshop dan aangeeft dat de cheque ontvangen is gaat ie pas naar processing, en dan bestaat de browser sessie natuurlijk niet meer. (<- zo ook getest).

M'n hypothese is dat dit bij een hoop payment providers dus zo gaat, en dat we hierdoor dus een hoop transacties missen.