### PR TITLE
Feat/disable button on cart page option

### DIFF
--- a/Components/Admin/Co2ok-AdminOverview.php
+++ b/Components/Admin/Co2ok-AdminOverview.php
@@ -65,6 +65,11 @@ class Co2ok_AdminOverview
             update_option('co2ok_optout', $_POST['co2ok_optout']);
         }
 
+        if (isset($_POST['disable_co2ok_button_on_cart']))
+        {
+            update_option('disable_co2ok_button_on_cart', $_POST['disable_co2ok_button_on_cart']);
+        }
+
         if ($_SERVER['REQUEST_METHOD'] === 'POST')
         {
             if (!isset($_POST['co2ok_statistics']))
@@ -79,13 +84,20 @@ class Co2ok_AdminOverview
                 update_option('co2ok_optout', 'off');
             }
 
+            if (!isset($_POST['disable_co2ok_button_on_cart']))
+            {
+                $_POST['disable_co2ok_button_on_cart'] = 'false';
+                update_option('disable_co2ok_button_on_cart', 'false');
+            }
+
             $graphQLClient = new \co2ok_plugin_woocommerce\Components\Co2ok_GraphQLClient(\co2ok_plugin_woocommerce\Co2ok_Plugin::$co2okApiUrl);
 
             $merchantId = get_option('co2ok_id', false);
             $co2ok_statistics = get_option('co2ok_statistics', 'off');
             $co2ok_optout = get_option('co2ok_optout', 'off');
+            $disable_co2ok_button_on_cart = get_option('disable_co2ok_button_on_cart', 'false');
 
-            $graphQLClient->mutation(function ($mutation) use ($merchantId, $co2ok_statistics, $co2ok_optout)
+            $graphQLClient->mutation(function ($mutation) use ($merchantId, $co2ok_statistics, $co2ok_optout, $disable_co2ok_button_on_cart)
             {
                 $mutation->setFunctionName('updateMerchant');
 
@@ -93,7 +105,8 @@ class Co2ok_AdminOverview
                     array(
                         'merchantId' => $merchantId,
                         'sendStats' => $co2ok_statistics,
-                        'optout' => $co2ok_optout
+                        'optout' => $co2ok_optout,
+                        'disable_co2ok_button_on_cart' => $disable_co2ok_button_on_cart
                     )
                 );
                 $mutation->setFunctionReturnTypes(array('ok'));
@@ -108,6 +121,7 @@ class Co2ok_AdminOverview
         $co2ok_button_template = get_option('co2ok_button_template', 'co2ok_button_template_default');
         $co2ok_statistics = get_option('co2ok_statistics', 'off');
         $co2ok_optout = get_option('co2ok_optout', 'off');
+        $disable_co2ok_button_on_cart = get_option('disable_co2ok_button_on_cart', 'false');
       
         include_once plugin_dir_path(__FILE__).'views/default.php';
     }

--- a/co2ok-plugin.php
+++ b/co2ok-plugin.php
@@ -264,40 +264,44 @@ if ( !class_exists( 'co2ok_plugin_woocommerce\Co2ok_Plugin' ) ) :
                 $this->helperComponent = new \co2ok_plugin_woocommerce\Components\Co2ok_HelperComponent();
 
                 add_action('woocommerce_after_order_notes', array($this, 'co2ok_checkout_checkbox'));
-                //add_action('woocommerce_cart_collaterals', array($this, 'co2ok_cart_checkbox'));
+                add_action('woocommerce_cart_collaterals', array($this, 'co2ok_cart_checkbox'));
                 add_action('woocommerce_cart_calculate_fees', array($this, 'co2ok_woocommerce_custom_surcharge'));
 
+                // Check if a value is given in the search bar for the Disable co2ok button on Cart option
                 $disable_co2ok_button_on_cart = isset($_GET['disable_co2ok_button_on_cart']) ? $_GET['disable_co2ok_button_on_cart'] : '';
-                // $disable_co2ok_button_on_cart = get_option('disable_co2ok_button_on_cart', 'false');
+
+                // If there is nothing set for the Disable Button on Cart option, just add the button
                 if ( !isset($_GET['disable_co2ok_button_on_cart']) &&  $disable_co2ok_button_on_cart == '' ){
                     add_action('woocommerce_cart_collaterals', array($this, 'co2ok_cart_checkbox'));
                 }
+
+                // User needs to insert what is inside the following braces (&disable_co2ok_button_on_cart=true)
+                // in the search bar to use this action
+                // Removes the button at Cart Page if the disable option is True and saves this to the wp database
                 if ( $disable_co2ok_button_on_cart == 'true' ) {
                     remove_action('woocommerce_cart_collaterals', array($this, 'co2ok_cart_checkbox'));
                     update_option('disable_co2ok_button_on_cart', 'true');
-                    // $disable_co2ok_button_on_cart= 'true';
-                    echo("<script>console.log('PHP: get is true');</script>");
-                    echo("<script>console.log('GET:".$_GET."');</script>");
-                    echo "<pre>";
-                    echo "POST";
-                    print_r($_POST);
-                    echo "GET";
-                    print_r($_GET);
-                    echo "</pre>";
                 }
-                
+
+                // User needs to insert what is inside the following braces (&disable_co2ok_button_on_cart=false)
+                // in the search bar to use this action
+                // Adds the button at Cart Page if the disable option is True and saves this to the wp database
                 if (  $disable_co2ok_button_on_cart == 'false' ) {
                     add_action('woocommerce_cart_collaterals', array($this, 'co2ok_cart_checkbox'));
-                    // $disable_co2ok_button_on_cart= 'false';
                     update_option('disable_co2ok_button_on_cart', 'false');
-                    echo("<script>console.log('PHP: get is false');</script>");
-                    echo("<script>console.log('GET:".$_GET."');</script>");
-                    echo "<pre>";
-                    echo "POST";
-                    print_r($_POST);
-                    echo "GET";
-                    print_r($_GET);
-                    echo "</pre>";
+                }
+
+                // Retrieve the disable button state (Either 'true' or 'false') from the wp databse
+                $saved_disabled_co2ok_button_on_cart = get_option('disable_co2ok_button_on_cart', 'false');
+
+                // If the retrieved state for disable button on Cart Page is True, remove the Button from Cart Page
+                if ( $saved_disabled_co2ok_button_on_cart == 'true' ) {
+                    remove_action('woocommerce_cart_collaterals', array($this, 'co2ok_cart_checkbox'));
+                }
+
+                // If the retrieved state for disable button on Cart Page is False, add the Button to Cart Page
+                if ( $saved_disabled_co2ok_button_on_cart == 'false' ) {
+                    add_action('woocommerce_cart_collaterals', array($this, 'co2ok_cart_checkbox'));
                 }
 
                 /**

--- a/co2ok-plugin.php
+++ b/co2ok-plugin.php
@@ -264,9 +264,57 @@ if ( !class_exists( 'co2ok_plugin_woocommerce\Co2ok_Plugin' ) ) :
                 $this->helperComponent = new \co2ok_plugin_woocommerce\Components\Co2ok_HelperComponent();
 
                 add_action('woocommerce_after_order_notes', array($this, 'co2ok_checkout_checkbox'));
-                add_action('woocommerce_cart_collaterals', array($this, 'co2ok_cart_checkbox'));
+                //add_action('woocommerce_cart_collaterals', array($this, 'co2ok_cart_checkbox'));
                 add_action('woocommerce_cart_calculate_fees', array($this, 'co2ok_woocommerce_custom_surcharge'));
 
+                $disable_co2ok_button_on_cart = get_option('disable_co2ok_button_on_cart', 'false');
+                if ( isset ($_GET['disable_co2ok_button_on_cart=true'] )) {
+                    $disable_co2ok_button_on_cart= 'true';
+                    echo("<script>console.log('PHP: get is true');</script>");
+                    echo("<script>console.log('GET:".$_GET."');</script>");
+                    echo "<pre>";
+                    echo "POST";
+                    print_r($_POST);
+                    echo "GET";
+                    print_r($_POST);
+                    echo "</pre>";
+                }
+                
+                if ( isset ($_GET['disable_co2ok_button_on_cart=false'] )) {
+                    $disable_co2ok_button_on_cart= 'false';
+                    echo("<script>console.log('PHP: get is false');</script>");
+                    echo("<script>console.log('GET:".$_GET."');</script>");
+                    echo "<pre>";
+                    echo "POST";
+                    print_r($_POST);
+                    echo "GET";
+                    print_r($_POST);
+                    echo "</pre>";
+                }
+
+                if ( $disable_co2ok_button_on_cart == 0 ) {
+                    add_action('woocommerce_cart_collaterals', array($this, 'co2ok_cart_checkbox'));
+                    echo("<script>console.log('PHP: action is true');</script>");
+                    echo("<script>console.log('GET:".$_GET."');</script>");
+                    echo "<pre>";
+                    echo "POST";
+                    print_r($_POST);
+                    echo "GET";
+                    print_r($_POST);
+                    echo "</pre>";
+                }
+
+                if ( $disable_co2ok_button_on_cart == 1 ) {
+                    remove_action('woocommerce_cart_collaterals', array($this, 'co2ok_cart_checkbox'));
+                    echo("<script>console.log('PHP: action is false');</script>");
+                    echo("<script>console.log('GET:".$_GET."');</script>");
+                    echo "<pre>";
+                    echo "POST";
+                    print_r($_POST);
+                    echo "GET";
+                    print_r($_POST);
+                    echo "</pre>";
+                }
                 /**
                  * Woocommerce' state for an order that's accepted and should be
                  * stored on our end is 'processing'

--- a/co2ok-plugin.php
+++ b/co2ok-plugin.php
@@ -267,54 +267,39 @@ if ( !class_exists( 'co2ok_plugin_woocommerce\Co2ok_Plugin' ) ) :
                 //add_action('woocommerce_cart_collaterals', array($this, 'co2ok_cart_checkbox'));
                 add_action('woocommerce_cart_calculate_fees', array($this, 'co2ok_woocommerce_custom_surcharge'));
 
-                $disable_co2ok_button_on_cart = get_option('disable_co2ok_button_on_cart', 'false');
-                if ( isset ($_GET['disable_co2ok_button_on_cart=true'] )) {
-                    $disable_co2ok_button_on_cart= 'true';
+                $disable_co2ok_button_on_cart = isset($_GET['disable_co2ok_button_on_cart']) ? $_GET['disable_co2ok_button_on_cart'] : '';
+                // $disable_co2ok_button_on_cart = get_option('disable_co2ok_button_on_cart', 'false');
+                if ( !isset($_GET['disable_co2ok_button_on_cart']) &&  $disable_co2ok_button_on_cart == '' ){
+                    add_action('woocommerce_cart_collaterals', array($this, 'co2ok_cart_checkbox'));
+                }
+                if ( $disable_co2ok_button_on_cart == 'true' ) {
+                    remove_action('woocommerce_cart_collaterals', array($this, 'co2ok_cart_checkbox'));
+                    update_option('disable_co2ok_button_on_cart', 'true');
+                    // $disable_co2ok_button_on_cart= 'true';
                     echo("<script>console.log('PHP: get is true');</script>");
                     echo("<script>console.log('GET:".$_GET."');</script>");
                     echo "<pre>";
                     echo "POST";
                     print_r($_POST);
                     echo "GET";
-                    print_r($_POST);
+                    print_r($_GET);
                     echo "</pre>";
                 }
                 
-                if ( isset ($_GET['disable_co2ok_button_on_cart=false'] )) {
-                    $disable_co2ok_button_on_cart= 'false';
+                if (  $disable_co2ok_button_on_cart == 'false' ) {
+                    add_action('woocommerce_cart_collaterals', array($this, 'co2ok_cart_checkbox'));
+                    // $disable_co2ok_button_on_cart= 'false';
+                    update_option('disable_co2ok_button_on_cart', 'false');
                     echo("<script>console.log('PHP: get is false');</script>");
                     echo("<script>console.log('GET:".$_GET."');</script>");
                     echo "<pre>";
                     echo "POST";
                     print_r($_POST);
                     echo "GET";
-                    print_r($_POST);
+                    print_r($_GET);
                     echo "</pre>";
                 }
 
-                if ( $disable_co2ok_button_on_cart == 0 ) {
-                    add_action('woocommerce_cart_collaterals', array($this, 'co2ok_cart_checkbox'));
-                    echo("<script>console.log('PHP: action is true');</script>");
-                    echo("<script>console.log('GET:".$_GET."');</script>");
-                    echo "<pre>";
-                    echo "POST";
-                    print_r($_POST);
-                    echo "GET";
-                    print_r($_POST);
-                    echo "</pre>";
-                }
-
-                if ( $disable_co2ok_button_on_cart == 1 ) {
-                    remove_action('woocommerce_cart_collaterals', array($this, 'co2ok_cart_checkbox'));
-                    echo("<script>console.log('PHP: action is false');</script>");
-                    echo("<script>console.log('GET:".$_GET."');</script>");
-                    echo "<pre>";
-                    echo "POST";
-                    print_r($_POST);
-                    echo "GET";
-                    print_r($_POST);
-                    echo "</pre>";
-                }
                 /**
                  * Woocommerce' state for an order that's accepted and should be
                  * stored on our end is 'processing'


### PR DESCRIPTION
Added feature - Disable Button On Cart Page Option
How to use:
Go to your browser's search bar and add:
&disable_co2ok_button_on_cart=true
at the end of the line and press enter

To turn the button back on for the cart page, go to your browser's search bar and add:
&disable_co2ok_button_on_cart=false
at the end of the line and press enter

This gets saved in the wordpress database, so next time you open your website it stays.

I've also added elaborate documentation in the code.

Debugging has been removed.