### PR TITLE
Scroll into view is now only used on mobile

### DIFF
--- a/js/co2ok-plugin.js
+++ b/js/co2ok-plugin.js
@@ -240,8 +240,10 @@ var Co2ok_JS = function ()
             jQuery(".co2ok_container").css({
               marginBottom: 200
             });
-            var elmnt = document.getElementById("infobox-view");
-            elmnt.scrollIntoView(false); // false leads to bottom of the infobox
+            if (this.IsMobile() == true ) {
+                var elmnt = document.getElementById("infobox-view");
+                elmnt.scrollIntoView(false); // false leads to bottom of the infobox
+            }
         },
 
         hideInfoBox : function()


### PR DESCRIPTION
Made a check if the button is shown on mobile or desktop using the IsMobile() function. Now only uses the scrollIntoView for the infobox when shown on mobile.