### PR TITLE
Feat/currency string adjustment

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ To get Gulp working you follow the following steps:
 
 
 ### Docker, WordPress and WooCommerce
-Upon installing Docker Desktop, clone the repo and, from repo directory, run:
+If desired, install Docker Desktop. Else/then clone the repo and, from repo directory, run:
 ```
 docker-compose up
 ```
 
-Open repo in browser from Docker Dashboard and follow the instructions to setup a WordPress page.
+Open repo in browser from Docker Dashboard and follow the instructions to setup a WordPress page. Or, if you are not using Docker Dashboard, open browser and go to localhost:8080
 
 Next, WooCommerce must be added. Follow this link, and use the Docker command line to add WooCommerce to your Docker:
 https://hub.docker.com/r/julianxhokaxhiu/docker-woocommerce

--- a/css/co2ok.css
+++ b/css/co2ok.css
@@ -395,6 +395,7 @@ img#co2ok_logo_minimal {
       border-radius: 30px;
       transition: all 0.4s ease;
       margin-left: -3px;
+      margin-top: -2px;
       padding: 5px;
       border: 10px #06d367;
       font: inherit;
@@ -444,7 +445,8 @@ img#co2ok_logo_minimal {
         .co2ok_container_minimal .co2ok_checkbox_container_minimal .inner_checkbox_label_minimal .comp_amount_label_minimal .inner_comp_amount_label_minimal .compensation_amount_minimal {
           position: absolute;
           margin: 0;
-          font-size: 11pt;
+          font-size: 16px;
+          margin-top: 0px;
           top: 50%;
           left: 50%;
           margin-right: -50%;
@@ -498,5 +500,5 @@ img#co2ok_logo_minimal {
       display: block;
       font-family: Roboto, sans-serif; }
     .co2ok_container .make_co2ok_minimal {
-      font-size: 21px;
+      font-size: 20px;
     }

--- a/css/co2ok.css
+++ b/css/co2ok.css
@@ -343,9 +343,9 @@ img#co2ok_logo_minimal {
       color: white;
       padding-left: 19px;
       left: -10px;
-      margin-top: 9px !important;
+      margin-top: 9px;
       float: right;
-      font-size: 16px !important;
+      font-size: 16px;
       font-weight: 500;
       letter-spacing: 0px;
       font-family: Roboto, sans-serif; }
@@ -356,9 +356,9 @@ img#co2ok_logo_minimal {
     color: #05B139;
     padding-left: 19px;
     left: -10px;
-    margin-top: 9px !important;
+    margin-top: 9px;
     float: right;
-    font-size: 16px !important;
+    font-size: 16px;
     font-weight: 500;
     letter-spacing: 0px;
     font-family: Roboto, sans-serif; }

--- a/css/co2ok.css
+++ b/css/co2ok.css
@@ -482,7 +482,7 @@ img#co2ok_logo_minimal {
           background-color: transparent;
           border-radius: 50%;
           display: inline-block;
-          margin-left: -25px;
+          margin-left: -20px;
           position: relative;
           bottom: 30px; }
           .co2ok_container_minimal .co2ok_checkbox_container_minimal .inner_checkbox_label_minimal .co2ok_payoff_minimal #p_minimal .co2ok_info_hitarea img {

--- a/js/co2ok-plugin.js
+++ b/js/co2ok-plugin.js
@@ -10,22 +10,19 @@ function minimumButton() {
   var compensation_amount_minimal = document.querySelector('.compensation_amount_minimal');
   var co2ok_info_hitare_minimal = document.querySelector('.co2ok_payoff_minimal');
   var inner_border_minimal = document.querySelector('.inner_comp_amount_label_minimal');
-  var comp_amount_minimal = document.querySelector('.comp_amount_label_minimal');
 
   var cad_length_minimal = cad_minimal.innerHTML.length;
-  var relative_font_size;
-  var relative_size_diff;
 
   //changes style relative to length of compensation
   if (cad_length_minimal > 10) {
 
-    relative_font_size = Math.floor(14 - cad_length_minimal / 12);
-    relative_size_diff = 12 - relative_font_size;
+    var relative_font_size = Math.floor(14 - cad_length_minimal / 12);
+    var relative_size_diff = 12 - relative_font_size;
 
   } else if (cad_length_minimal > 7) {
 
-    relative_font_size = Math.floor(14 - cad_length_minimal / 14);
-    relative_size_diff = 14 - relative_font_size;
+    var relative_font_size = Math.floor(14 - cad_length_minimal / 14);
+    var relative_size_diff = 14 - relative_font_size;
 
   }
 
@@ -33,24 +30,14 @@ function minimumButton() {
 
     cad_minimal.style.fontSize = relative_font_size - relative_size_diff + 'px';
     make_minimal.style.fontSize = relative_font_size - relative_size_diff + 3 + 'px';
-    cad_minimal.style.marginTop = '0px';
     co2ok_logo_minimal.style.width = 45 - relative_size_diff + 'px';
     comp_amount_label_minimal.style.marginLeft = -(10 + compensation_amount_minimal.textContent.length) - cad_length_minimal +'px';
     comp_amount_label_minimal.style.width = 70 + cad_length_minimal + 'px';
     inner_border_minimal.style.width = 65 + cad_length_minimal + 'px';
-    comp_amount_minimal.style.marginTop = '-4px';
+    comp_amount_label_minimal.style.marginTop = '-4px';
     co2ok_info_hitare_minimal.style.paddingLeft = cad_length_minimal * 2 + 'px';
     co2ok_info_hitare_minimal.style.marginTop = '-3px';
 
-
-  } else {
-
-    cad_minimal.style.fontSize = '16px';
-    make_minimal.style.fontSize = '20px';
-    cad_minimal.style.marginTop = '0px';
-    co2ok_logo_minimal.style.width = '55px';
-    comp_amount_minimal.style.marginTop = '-2px';
-    comp_amount_label_minimal.style.marginLeft = '-3px';
 
   }
 }
@@ -61,20 +48,18 @@ function defaultButton() {
   var cad = document.querySelector('.compensation_amount_default');
   var co2ok_logo = document.querySelector('.co2ok_logo_default');
   var cad_length = cad.innerHTML.length;
-  var relative_font_size;
-  var relative_size_diff;
 
   //changes style relative to length of compensation
   if (cad_length > 10) {
 
-    relative_font_size = Math.floor(14 - cad_length / 14);
-    relative_size_diff = 14 - relative_font_size;
+    var relative_font_size = Math.floor(14 - cad_length / 14);
+    var relative_size_diff = 14 - relative_font_size;
     cad.style.marginTop = relative_font_size + 'px';
 
   } else if (cad_length > 7) {
 
-    relative_font_size = Math.floor(16 - cad_length / 16);
-    relative_size_diff = 16 - relative_font_size;
+    var relative_font_size = Math.floor(16 - cad_length / 16);
+    var relative_size_diff = 16 - relative_font_size;
     cad.style.marginTop = relative_font_size - 4 + 'px';
 
   }
@@ -86,15 +71,7 @@ function defaultButton() {
     make.style.fontSize = relative_font_size - relative_size_diff + 1 + 'px';
     co2ok_logo.style.width = 45 - relative_size_diff + 'px';
 
-  } else {
-
-    cad.style.fontSize = '16px';
-    cad.style.marginTop = '9px';
-    make.style.fontSize = '18px';
-    co2ok_logo.style.width = '55px';
-
   }
-
 }
 
 
@@ -191,15 +168,6 @@ var Co2ok_JS = function () {
                     // var pathName = window.location.pathname;
                     // var make_minimal = document.querySelector('.make_co2ok_minimal');
 
-                    if(document.querySelector('.qty') != null) {
-
-                      try{
-                        var qty = document.querySelector('.qty');
-                        var qtyVal = qty.value.length;
-                      } catch (e) {
-                        var qtyVal = 1;
-                      }
-
                       if(co2ok_temp_global.id == 'default_co2ok_temp') {
 
                         defaultButton();
@@ -209,24 +177,6 @@ var Co2ok_JS = function () {
                         minimumButton();
 
                       }
-
-                    } else {
-
-                      if(document.querySelector('.product-quantity') != null) {
-                        //checkout button
-                        if(co2ok_temp_global.id == 'default_co2ok_temp') {
-
-                          defaultButton();
-
-                        } else {
-
-                          minimumButton();
-
-                        }
-
-                      }
-                    }
-
                   }
 
                 if(jQuery(".co2ok_container").length ) {

--- a/js/co2ok-plugin.js
+++ b/js/co2ok-plugin.js
@@ -82,6 +82,7 @@ function defaultButton() {
   if (cad_length > 7) {
 
     cad.style.fontSize = relative_font_size - relative_size_diff + 'px';
+    cad.style.left = '-20px';
     make.style.fontSize = relative_font_size - relative_size_diff + 'px';
     co2ok_logo.style.width = 45 - relative_size_diff + 'px';
 

--- a/js/co2ok-plugin.js
+++ b/js/co2ok-plugin.js
@@ -1,99 +1,97 @@
 var co2ok_temp_global = document.querySelector('.co2ok_global_temp');
 
 
-function minimumButton()
-{
+function minimumButton() {
 
   var cad_minimal = document.querySelector('.compensation_amount_minimal');
   var make_minimal = document.querySelector('.make_co2ok_global');
   var co2ok_logo_minimal = document.querySelector('.co2ok_logo_minimal');
+  var comp_amount_label_minimal = document.querySelector('.comp_amount_label_minimal');
+  var compensation_amount_minimal = document.querySelector('.compensation_amount_minimal');
+  var co2ok_info_hitare_minimal = document.querySelector('.co2ok_payoff_minimal');
+  var inner_border_minimal = document.querySelector('.inner_comp_amount_label_minimal');
+  var cad_length_minimal = cad_minimal.innerHTML.length;
+  var relative_font_size;
+  var relative_size_diff;
 
-  try{
-    var holdValue = 0;
-    //check for all .qtholdQ and finds longest qty to prevent currency size issue
-    var allQtys = document.querySelectorAll('.qty');
-    for (var i = 0; i < allQtys.length; i++) {
-      if (allQtys[i].value > holdValue) {
-        holdValue = allQtys[i].value;
-      }
-    }
-    var productQuantityLength = holdValue.length;
+  //changes style relative to length of compensation
+  if (cad_length_minimal > 10) {
+    relative_font_size = Math.floor(14 - cad_length_minimal / 12);
+    relative_size_diff = 12 - relative_font_size;
+  } else if (cad_length_minimal > 7) {
+    relative_font_size = Math.floor(14 - cad_length_minimal / 14);
+    relative_size_diff = 14 - relative_font_size;
+    cad_minimal.style.marginTop = relative_font_size - 4 + 'px';
   }
-  catch (e) {
-    var productQuantityLength = 1;
-  }
 
-  if(qtyVal > 1)
-  {
+  if (cad_length_minimal > 7) {
 
-     cad_minimal.style.fontSize = 15 - qtyVal+'px';
-    // cad_minimal.style.marginTop = 9 + qtyVal+'px';
-     make_minimal.style.fontSize = 18 - qtyVal+'px';
-     co2ok_logo_minimal.style.width = 52 - qtyVal+'px';
+    cad_minimal.style.fontSize = relative_font_size - relative_size_diff + 'px';
+    make_minimal.style.fontSize = relative_font_size - relative_size_diff + 'px';
+    cad_minimal.style.marginTop = '0px';
+    co2ok_logo_minimal.style.width = 45 - relative_size_diff + 'px';
+    comp_amount_label_minimal.style.marginLeft = -(10 + compensation_amount_minimal.textContent.length) - cad_length_minimal +'px';
+    comp_amount_label_minimal.style.width = 70 + cad_length_minimal + 'px';
+    inner_border_minimal.style.width = 65 + cad_length_minimal + 'px';
+    co2ok_info_hitare_minimal.style.paddingLeft = cad_length_minimal * 2 + 'px';
 
-     //idk if this need to go here
-     comp_amount_label_minimal.style.marginLeft = -(10 + compensation_amount_minimal.textContent.length) - qtyVal +'px';
+  } else {
 
-  }else{
-
-    cad_minimal.style.fontSize = '18px';
-  //  cad_minimal.style.marginTop = '12px';
-    make_minimal.style.fontSize = '21px';
+    cad_minimal.style.fontSize = '16px';
+    make_minimal.style.fontSize = '20px';
+    cad_minimal.style.marginTop = '0px';
     co2ok_logo_minimal.style.width = '55px';
-
-    //idk if this needs to go her
     comp_amount_label_minimal.style.marginLeft = '-3px';
 
-
-  }
-  if (cad.innerHTML.length > 7) {
-    //check 1
-    console.log("minimal 1")
-    cad_minimal.style.fontSize = '15px';
-    cad_minimal.style.marginTop = '10px';
-    make_minimal.style.fontSize = '15px';
-    co2ok_logo_minimal.style.width = '50px';
   }
 }
 
-function defaultButton()
-{
+function defaultButton() {
 
   var cad = document.querySelector('.compensation_amount_default');
-  var make = document.querySelector('.make_co2ok_default');
   var co2ok_logo = document.querySelector('.co2ok_logo_default');
+  var cad_length = cad.innerHTML.length;
+  var relative_font_size;
+  var relative_size_diff;
 
-    console.log("in default button", cad.innerHTML, cad.innerHTML.length);
-    if (cad.innerHTML.length > 10) {
-      var relativeSize = Math.floor(14 - cad.innerHTML.length / 14);
-      var diff = 14 - relativeSize;
-      cad.style.marginTop = relativeSize + 'px';
-    } else {
-      var relativeSize = Math.floor(16 - cad.innerHTML.length / 16);
-      var diff = 16 - relativeSize;
-      cad.style.marginTop = relativeSize - 4 + 'px';
-    }
-    if (cad.innerHTML.length > 7) {
-      //check 2
-      console.log("2");
+  //changes style relative to length of compensation
+  if (cad_length > 10) {
 
-      cad.style.fontSize = relativeSize - diff + 'px';
-      make.style.fontSize = relativeSize - diff + 'px';
-      co2ok_logo.style.width = 45 - diff + 'px';
-    }else{
-      cad.style.fontSize = '16px';
-      cad.style.marginTop = '9px';
-      make.style.fontSize = '18px';
-      co2ok_logo.style.width = '55px';
-    }
+    relative_font_size = Math.floor(14 - cad_length / 14);
+    relative_size_diff = 14 - relative_font_size;
+    cad.style.marginTop = relative_font_size + 'px';
+
+  } else if (cad_length > 7) {
+
+    relative_font_size = Math.floor(16 - cad_length / 16);
+    relative_size_diff = 16 - relative_font_size;
+    cad.style.marginTop = relative_font_size - 4 + 'px';
+
+  }
+
+  if (cad_length > 7) {
+
+    cad.style.fontSize = relative_font_size - relative_size_diff + 'px';
+    make.style.fontSize = relative_font_size - relative_size_diff + 'px';
+    co2ok_logo.style.width = 45 - relative_size_diff + 'px';
+
+  } else {
+
+    cad.style.fontSize = '16px';
+    cad.style.marginTop = '9px';
+    make.style.fontSize = '18px';
+    co2ok_logo.style.width = '55px';
+
+  }
+
 }
 
 
-if(document.querySelector('.qty') != null && document.querySelector('.compensation_amount_default') != null){
+if(document.querySelector('.qty') != null && document.querySelector('.compensation_amount_default') != null) {
 
    defaultButton();
 
-}else if(document.querySelector('.qty') != null && document.querySelector('.compensation_amount_minimal') != null){
+} else if(document.querySelector('.qty') != null && document.querySelector('.compensation_amount_minimal') != null) {
 
    minimumButton();
 
@@ -102,8 +100,7 @@ if(document.querySelector('.qty') != null && document.querySelector('.compensati
 
 var co2ok_global = {
 
-    IsMobile: function()
-    {
+    IsMobile: function() {
         // if one of the Mobile models, IsMobile is true.
         var IsMobile = false;
         if(/(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|ipad|iris|kindle|Android|Silk|lge |maemo|midp|mmp|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows (ce|phone)|xda|xiino/i.test(navigator.userAgent)
@@ -116,8 +113,7 @@ var co2ok_global = {
 
 }
 
-var Co2ok_JS = function ()
-{
+var Co2ok_JS = function () {
 
     var image_url = plugin.url;
 
@@ -169,107 +165,64 @@ var Co2ok_JS = function ()
 
     return {
 
-        Init: function ()
-        {
+        Init: function () {
             this.RegisterBindings();
             this.RegisterInfoBox();
             this.RegisterRefreshHandling();
 
             var _this = this;
 
-
             jQuery(document).ready(function () {
                 function compensationAmountTextSize() {
 
                     //cad = compensation_amount_default
                     _this.GetPercentageFromMiddleware();
-                    var pathName = window.location.pathname;
-                    var make_minimal = document.querySelector('.make_co2ok_minimal');
+                    // var pathName = window.location.pathname;
+                    // var make_minimal = document.querySelector('.make_co2ok_minimal');
 
-                    var cad = document.querySelector('.compensation_amount_default');
-                    var make = document.querySelector('.make');
-                    var co2ok_logo = document.querySelector('.co2ok_logo_default');
-
-                    //cad = compensation_amount_minimun
-                    var cad_minimal = document.querySelector('.compensation_amount_minimal');
-                    var co2ok_logo_minimal = document.querySelector('.co2ok_logo_minimal');
-                    var compensation_amount_global = document.querySelector('.compensation_amount_global');
-                    var comp_amount_label_minimal = document.querySelector('.comp_amount_label_minimal');
-                  //  var global = document.querySelector('.global');
-
-                    if(document.querySelector('.qty') != null){
+                    if(document.querySelector('.qty') != null) {
 
                       try{
                         var qty = document.querySelector('.qty');
                         var qtyVal = qty.value.length;
-                      }
-                      catch (e) {
+                      } catch (e) {
                         var qtyVal = 1;
                       }
 
-                      if(co2ok_temp_global.id == 'default_co2ok_temp')
-                      {
-                        console.log("going in default here");
+                      if(co2ok_temp_global.id == 'default_co2ok_temp') {
+
                         defaultButton();
 
-                      }else{
+                      } else {
 
                         minimumButton();
 
                       }
 
-                    }else{
-                      if(document.querySelector('.product-quantity') != null){
-                       checkoutButton();
-                      }
+                    } else {
 
-                    }
+                      if(document.querySelector('.product-quantity') != null) {
+                        //checkout button
+                        if(co2ok_temp_global.id == 'default_co2ok_temp') {
 
-                    function checkoutButton()
-                    {
-                      console.log("checkoutButton");
-                      var comp_amount_label_minimal = document.querySelector('.comp_amount_label_minimal');
-                      // var productQuantityLength = productQuantity.textContent.length - 2;
-                      var compensation_amount_minimal = document.querySelector('.compensation_amount_minimal');
+                          defaultButton();
 
-                        var compensationAmountLength = compensation_amount_global.textContent.length;
-                        console.log(compensation_amount_global.textContent, compensationAmountLength);
-                        if(co2ok_temp_global.id == 'default_co2ok_temp')
-                        {
+                        } else {
 
-                          if(compensationAmountLength > 7){
-                            cad.style.fontSize = 16 - compensationAmountLength / 2.5 +'px';
-                            cad.style.marginTop = 10 + compensationAmountLength / 2.5 +'px';
-                            make.style.fontSize = 18 - compensationAmountLength / 2.5 +'px';
-                            co2ok_logo.style.width = 55 - compensationAmountLength / 2.5 +'px';
-                          }else{
-                            cad.style.fontSize = '16px';
-                            cad.style.marginTop= '9px';
-                            make.style.fontSize = '18px';
-                            co2ok_logo.style.width = '55px';
-                          }
-                        }else{
-                          if(compensationAmountLength > 7){
-                            cad_minimal.style.fontSize = 18 - (compensationAmountLength - 3)+'px';
-                            make_minimal.style.fontSize = 21 - (compensationAmountLength - 3)+'px';
-                            co2ok_logo_minimal.style.width = 55 - (compensationAmountLength - 3)+'px';
-                            comp_amount_label_minimal.style.marginLeft = -(10 + compensation_amount_minimal.textContent.length) - compensationAmountLength +'px';
-                          }else{
+                          minimumButton();
 
-                            cad_minimal.style.fontSize = '18px';
-                            make_minimal.style.fontSize = '21px';
-                            co2ok_logo_minimal.style.width = '55px';
-                            comp_amount_label_minimal.style.marginLeft = '-3px';
-                          }
                         }
+
+                      }
                     }
-                }
+
+                  }
 
                 if(jQuery(".co2ok_container").length ) {
                     compensationAmountTextSize();
                 }
 
-                jQuery( document.body ).on( 'updated_cart_totals', function(){
+                jQuery( document.body ).on( 'updated_cart_totals', function() {
                     compensationAmountTextSize();
 
                 });
@@ -282,12 +235,11 @@ var Co2ok_JS = function ()
                 jQuery("#co2ok_logo").attr("src", image_url + '/logo.svg');
             }
 
-            if(jQuery('#co2ok_cart').is(":checked"))
-            {
+            if(jQuery('#co2ok_cart').is(":checked")) {
                 jQuery("#co2ok_logo").attr("src", image_url + '/logo_wit.svg');
             }
 
-            if(jQuery("#co2ok_cart").length){ // if the co2ok cart is present, set text and logo based on background brightness
+            if(jQuery("#co2ok_cart").length) { // if the co2ok cart is present, set text and logo based on background brightness
                 // adaptiveTextColor();
 
                 // if(calcBackgroundBrightness() > 185){ // picks logo based on background brightness for minimal button design
@@ -299,8 +251,7 @@ var Co2ok_JS = function ()
             }
 
         },
-        GetPercentageFromMiddleware: function()
-        {
+        GetPercentageFromMiddleware: function() {
             var merchant_id = jQuery('.co2ok_container').attr('data-merchant-id');
             var products = JSON.parse(decodeURIComponent(jQuery('.co2ok_container').attr('data-cart')));
 
@@ -308,8 +259,7 @@ var Co2ok_JS = function ()
                 products: []
             }
 
-            jQuery(products).each(function(i)
-            {
+            jQuery(products).each(function(i) {
                 var ProductData ={
                     name: products[i].name,
                     brand: products[i].brand,
@@ -329,14 +279,12 @@ var Co2ok_JS = function ()
 
             var promise = CO2ok.getFootprint(merchant_id,CartData);
 
-            promise.then(function(percentage)
-            {
+            promise.then(function(percentage) {
                 var data = {
                     'action': 'co2ok_ajax_set_percentage',
                     'percentage': percentage
                 };
-                jQuery.post(ajax_object.ajax_url, data, function(response)
-                {
+                jQuery.post(ajax_object.ajax_url, data, function(response) {
                     if (typeof response.compensation_amount != 'undefined') {
                         jQuery('[class*="compensation_amount"]').html('+'+response.compensation_amount);
                     }
@@ -345,11 +293,9 @@ var Co2ok_JS = function ()
 
         },
 
-        RegisterBindings: function()
-        {
+        RegisterBindings: function() {
 
-            jQuery('#co2ok_cart').click(function (event)
-            {
+            jQuery('#co2ok_cart').click(function (event) {
 
                  function placeVideoRewardBox() {
 
@@ -379,8 +325,7 @@ var Co2ok_JS = function ()
                       });
                     }
                   }
-                  function ShowVideoRewardBox()
-                  {
+                  function ShowVideoRewardBox() {
                     jQuery(".co2ok_videoRewardBox_container").removeClass('VideoRewardBox-hidden')
                     jQuery(".co2ok_videoRewardBox_container").addClass('ShowVideoRewardBox')
                     jQuery(".co2ok_videoRewardBox_container").css({
@@ -404,8 +349,7 @@ var Co2ok_JS = function ()
                         );
                     }
                   }
-                  function hideVideoRewardBox()
-                  {
+                  function hideVideoRewardBox() {
                     jQuery(".co2ok_videoRewardBox_container").removeClass('ShowVideoRewardBox')
                     jQuery(".co2ok_videoRewardBox_container").addClass('VideoRewardBox-hidden')
                     jQuery(".co2ok_videoRewardBox_container").css({
@@ -418,8 +362,7 @@ var Co2ok_JS = function ()
                     hideVideoRewardBox();
                 }
 
-                if(jQuery(this).is(":checked"))
-                {
+                if(jQuery(this).is(":checked")) {
                     jQuery("#co2ok_logo").attr("src", image_url + '/logo_wit.svg');
 
                     if (jQuery(".co2ok_videoRewardBox_container").length) {
@@ -437,21 +380,19 @@ var Co2ok_JS = function ()
 
                     if (jQuery('#co2ok_checkout_hidden').length === 0) {
                         jQuery('form.woocommerce-checkout, .woocommerce form').append('<input type="checkbox" class="input-checkbox " name="co2ok_cart" id="co2ok_checkout_hidden" checked value="1" style="display:none">');
-                    }
-                    else {
+                    } else {
                         jQuery('#co2ok_checkout_hidden').remove();
                         jQuery('form.woocommerce-checkout, .woocommerce form').append('<input type="checkbox" class="input-checkbox " name="co2ok_cart" id="co2ok_checkout_hidden" checked value="1" style="display:none">');
                     }
 
-                }else {
+                } else {
                     jQuery('.co2ok_checkbox_container').removeClass('selected');
                     jQuery('.co2ok_checkbox_container').addClass('unselected');
                     jQuery('.woocommerce-cart-form').append('<input type="checkbox" class="input-checkbox " name="co2ok_cart" id="co2ok_cart_hidden"  checked value="0" style="display:none">');
 
                     if (jQuery('#co2ok_checkout_hidden').length === 0) {
                         jQuery('form.woocommerce-checkout, .woocommerce form').append('<input type="checkbox" class="input-checkbox " name="co2ok_cart" id="co2ok_checkout_hidden" checked value="0" style="display:none">');
-                    }
-                    else {
+                    } else {
                         jQuery('#co2ok_checkout_hidden').remove();
                         jQuery('form.woocommerce-checkout, .woocommerce form').append('<input type="checkbox" class="input-checkbox " name="co2ok_cart" id="co2ok_checkout_hidden" checked value="0" style="display:none">');
                     }
@@ -460,19 +401,16 @@ var Co2ok_JS = function ()
 
 
                 jQuery('.woocommerce-cart-form, .woocommerce form').find('input.qty').first().unbind();
-                jQuery('.woocommerce-cart-form, .woocommerce form').find('input.qty').first().bind('change', function()
-                {
-                    setTimeout(function()
-                    // This timeout it to prevent multiple ajax calls when a user clicks multiple times (e.g. from 1 to 5 apples)
-                    {
+                jQuery('.woocommerce-cart-form, .woocommerce form').find('input.qty').first().bind('change', function() {
+                  // This timeout it to prevent multiple ajax calls when a user clicks multiple times (e.g. from 1 to 5 apples)
+                    setTimeout(function() {
                         jQuery("[name='update_cart']").trigger("click");
                     },200);
                 });
 
-                setTimeout(function()
-                {
+                setTimeout(function() {
                     jQuery('body').trigger('update_checkout');
-                    
+
                     // prevent update cart firing on cart+checkout pages
                     if (! jQuery( 'form.checkout' ).length) {
                       // This fixes fee adding for shops with a disabled update cart button
@@ -485,14 +423,12 @@ var Co2ok_JS = function ()
                 jQuery('.woocommerce-cart-form').find('input.qty').first().trigger("change");
             });
 
-            jQuery('#co2ok_cart, #checkbox_label, .co2ok_checkbox_container').click(function(event)
-            {
-                if(!jQuery(this).is("#co2ok_cart"))
-                {
+            jQuery('#co2ok_cart, #checkbox_label, .co2ok_checkbox_container').click(function(event) {
+                if(!jQuery(this).is("#co2ok_cart")) {
                     jQuery("[id='co2ok_cart']").trigger("click");
                 }
                 event.stopPropagation();
-            }).find('.co2ok_info_hitarea').click(function (event){
+            }).find('.co2ok_info_hitarea').click(function (event) {
                 event.stopPropagation();
             })
         },
@@ -523,8 +459,7 @@ var Co2ok_JS = function ()
             });
           }
         },
-        ShowInfoBox  : function()
-        {
+        ShowInfoBox  : function() {
             if (!jQuery(".co2ok_infobox_container").hasClass('ShowInfoBox')){
               jQuery(".co2ok_infobox_container").removeClass('infobox-hidden')
               jQuery(".co2ok_infobox_container").addClass('ShowInfoBox')
@@ -538,8 +473,7 @@ var Co2ok_JS = function ()
             }
         },
 
-        hideInfoBox : function()
-        {
+        hideInfoBox : function() {
             jQuery(".co2ok_infobox_container").removeClass('ShowInfoBox')
             jQuery(".co2ok_infobox_container").addClass('infobox-hidden')
             jQuery(".co2ok_container").css({
@@ -548,10 +482,7 @@ var Co2ok_JS = function ()
         },
 
 
-
-
-        modalRegex: function(e)
-         {
+        modalRegex: function(e) {
              return jQuery(e.target).hasClass("svg-img") ||
              jQuery(e.target).hasClass("svg-img-large") ||
              jQuery(e.target).hasClass("text-block") ||
@@ -563,18 +494,16 @@ var Co2ok_JS = function ()
          },
 
 
-        RegisterInfoBox : function()
-        {
+        RegisterInfoBox : function() {
 
             var _this = this;
 
-            jQuery(".co2ok_info_keyboardarea").focus(function(){
+            jQuery(".co2ok_info_keyboardarea").focus(function() {
                 _this.ShowInfoBox();
                 jQuery(".first-text-to-select").focus();
             });
 
-            jQuery('body').click(function(e)
-            {
+            jQuery('body').click(function(e) {
               if(!_this.modalRegex(e))
               {
                 _this.hideInfoBox();
@@ -585,7 +514,7 @@ var Co2ok_JS = function ()
 
             });
 
-            jQuery('body').on("touchstart",function(e){
+            jQuery('body').on("touchstart",function(e) {
 
               if(!_this.modalRegex(e)){
                 _this.hideInfoBox();
@@ -613,8 +542,7 @@ var Co2ok_JS = function ()
             }
         },
 
-        RegisterRefreshHandling : function()
-        {
+        RegisterRefreshHandling : function() {
           // Some shops actually rerender elements such as our button upon cart update
           // this ofc breaks our bindings.
           jQuery( document.body ).on( 'updated_cart_totals', function(){
@@ -635,14 +563,13 @@ var Co2ok_JS = function ()
 
 jQuery(document).ready(function() {
   // Checks wether A/B testing is enabled and dis/en-ables JS accordingly and removes the co2ok button
-  if (Co2ok_JS().getCookieValue('co2ok_ab_enabled') == 1 && !Co2ok_JS().getCookieValue('co2ok_ab_hide'))
-  {
+  if (Co2ok_JS().getCookieValue('co2ok_ab_enabled') == 1 && !Co2ok_JS().getCookieValue('co2ok_ab_hide')) {
     var future = new Date();
     future.setTime(future.getTime() + 30 * 24 * 3600 * 1000);
     var random_A_or_B = Math.round(Math.random());
     document.cookie = "co2ok_ab_hide=" + random_A_or_B + "; expires=" + future.toUTCString() + "; path=/";
   }
-  if (Co2ok_JS().getCookieValue('co2ok_ab_enabled') == 1 && Co2ok_JS().getCookieValue('co2ok_ab_hide')){
+  if (Co2ok_JS().getCookieValue('co2ok_ab_enabled') == 1 && Co2ok_JS().getCookieValue('co2ok_ab_hide')) {
     if (Co2ok_JS().getCookieValue('co2ok_ab_hide') % 2 == 0)
     {
       jQuery('.co2ok_container').remove();
@@ -650,7 +577,7 @@ jQuery(document).ready(function() {
     }
   }
 
-  if(jQuery("#co2ok_cart").length){
+  if(jQuery("#co2ok_cart").length) {
       Co2ok_JS().Init()
   }
 })

--- a/js/co2ok-plugin.js
+++ b/js/co2ok-plugin.js
@@ -10,18 +10,23 @@ function minimumButton() {
   var compensation_amount_minimal = document.querySelector('.compensation_amount_minimal');
   var co2ok_info_hitare_minimal = document.querySelector('.co2ok_payoff_minimal');
   var inner_border_minimal = document.querySelector('.inner_comp_amount_label_minimal');
+  var comp_amount_minimal = document.querySelector('.comp_amount_label_minimal');
+
   var cad_length_minimal = cad_minimal.innerHTML.length;
   var relative_font_size;
   var relative_size_diff;
 
   //changes style relative to length of compensation
   if (cad_length_minimal > 10) {
+
     relative_font_size = Math.floor(14 - cad_length_minimal / 12);
     relative_size_diff = 12 - relative_font_size;
+
   } else if (cad_length_minimal > 7) {
+
     relative_font_size = Math.floor(14 - cad_length_minimal / 14);
     relative_size_diff = 14 - relative_font_size;
-    cad_minimal.style.marginTop = relative_font_size - 4 + 'px';
+
   }
 
   if (cad_length_minimal > 7) {
@@ -33,7 +38,10 @@ function minimumButton() {
     comp_amount_label_minimal.style.marginLeft = -(10 + compensation_amount_minimal.textContent.length) - cad_length_minimal +'px';
     comp_amount_label_minimal.style.width = 70 + cad_length_minimal + 'px';
     inner_border_minimal.style.width = 65 + cad_length_minimal + 'px';
+    comp_amount_minimal.style.marginTop = '-4px';
     co2ok_info_hitare_minimal.style.paddingLeft = cad_length_minimal * 2 + 'px';
+    co2ok_info_hitare_minimal.style.marginTop = '-3px';
+
 
   } else {
 
@@ -41,6 +49,7 @@ function minimumButton() {
     make_minimal.style.fontSize = '20px';
     cad_minimal.style.marginTop = '0px';
     co2ok_logo_minimal.style.width = '55px';
+    comp_amount_minimal.style.marginTop = '-2px';
     comp_amount_label_minimal.style.marginLeft = '-3px';
 
   }
@@ -48,6 +57,7 @@ function minimumButton() {
 
 function defaultButton() {
 
+  var make = document.querySelector('.make_co2ok_default');
   var cad = document.querySelector('.compensation_amount_default');
   var co2ok_logo = document.querySelector('.co2ok_logo_default');
   var cad_length = cad.innerHTML.length;

--- a/js/co2ok-plugin.js
+++ b/js/co2ok-plugin.js
@@ -9,11 +9,18 @@ function minimumButton()
   var co2ok_logo_minimal = document.querySelector('.co2ok_logo_minimal');
 
   try{
-    var qty = document.querySelector('.qty');
-    var qtyVal = qty.value.length;
+    var holdValue = 0;
+    //check for all .qtholdQ and finds longest qty to prevent currency size issue
+    var allQtys = document.querySelectorAll('.qty');
+    for (var i = 0; i < allQtys.length; i++) {
+      if (allQtys[i].value > holdValue) {
+        holdValue = allQtys[i].value;
+      }
+    }
+    var productQuantityLength = holdValue.length;
   }
   catch (e) {
-    var qtyVal = 1;
+    var productQuantityLength = 1;
   }
 
   if(qtyVal > 1)
@@ -24,6 +31,9 @@ function minimumButton()
      make_minimal.style.fontSize = 18 - qtyVal+'px';
      co2ok_logo_minimal.style.width = 52 - qtyVal+'px';
 
+     //idk if this need to go here
+     comp_amount_label_minimal.style.marginLeft = -(10 + compensation_amount_minimal.textContent.length) - qtyVal +'px';
+
   }else{
 
     cad_minimal.style.fontSize = '18px';
@@ -31,8 +41,19 @@ function minimumButton()
     make_minimal.style.fontSize = '21px';
     co2ok_logo_minimal.style.width = '55px';
 
-  }
+    //idk if this needs to go her
+    comp_amount_label_minimal.style.marginLeft = '-3px';
 
+
+  }
+  if (cad.innerHTML.length > 7) {
+    //check 1
+    console.log("minimal 1")
+    cad_minimal.style.fontSize = '15px';
+    cad_minimal.style.marginTop = '10px';
+    make_minimal.style.fontSize = '15px';
+    co2ok_logo_minimal.style.width = '50px';
+  }
 }
 
 function defaultButton()
@@ -42,32 +63,29 @@ function defaultButton()
   var make = document.querySelector('.make_co2ok_default');
   var co2ok_logo = document.querySelector('.co2ok_logo_default');
 
-    try{
-      var qty = document.querySelector('.qty');
-      var qtyVal = qty.value.length;
+    console.log("in default button", cad.innerHTML, cad.innerHTML.length);
+    if (cad.innerHTML.length > 10) {
+      var relativeSize = Math.floor(14 - cad.innerHTML.length / 14);
+      var diff = 14 - relativeSize;
+      cad.style.marginTop = relativeSize + 'px';
+    } else {
+      var relativeSize = Math.floor(16 - cad.innerHTML.length / 16);
+      var diff = 16 - relativeSize;
+      cad.style.marginTop = relativeSize - 4 + 'px';
     }
-    catch (e) {
-      var qtyVal = 1;
-    }
+    if (cad.innerHTML.length > 7) {
+      //check 2
+      console.log("2");
 
-    if(qtyVal > 1)
-    {
-
-       cad.style.fontSize = 16 - qtyVal+'px';
-       cad.style.marginTop = 12 + qtyVal+'px';
-       make.style.fontSize = 18 - qtyVal+'px';
-       co2ok_logo.style.width = 55 - qtyVal+'px';
-
+      cad.style.fontSize = relativeSize - diff + 'px';
+      make.style.fontSize = relativeSize - diff + 'px';
+      co2ok_logo.style.width = 45 - diff + 'px';
     }else{
-
       cad.style.fontSize = '16px';
-      cad.style.marginTop = '12px';
+      cad.style.marginTop = '9px';
       make.style.fontSize = '18px';
       co2ok_logo.style.width = '55px';
-
     }
-
-
 }
 
 
@@ -188,10 +206,10 @@ var Co2ok_JS = function ()
                       catch (e) {
                         var qtyVal = 1;
                       }
-                  
+
                       if(co2ok_temp_global.id == 'default_co2ok_temp')
                       {
-
+                        console.log("going in default here");
                         defaultButton();
 
                       }else{
@@ -201,113 +219,49 @@ var Co2ok_JS = function ()
                       }
 
                     }else{
-
-                      if(document.querySelector('.productQuantity') != null){
+                      if(document.querySelector('.product-quantity') != null){
                        checkoutButton();
                       }
 
                     }
 
-
-                    function defaultButton()
-                    {
-
-                      if(qtyVal > 1)
-                      {
-
-                        cad.style.fontSize = 16 - qtyVal+'px';
-                        cad.style.marginTop = 10 + qtyVal+'px';
-                        make.style.fontSize = 18 - qtyVal+'px';
-                        co2ok_logo.style.width = 55 - qtyVal+'px';
-
-                      }else{
-
-                        cad.style.fontSize = '16px';
-                        cad.style.marginTop = '10px';
-                        make.style.fontSize = '18px';
-                        co2ok_logo.style.width = '55px';
-
-                      }
-
-                    }
-
-
-                    function minimumButton()
-                    {
-
-                      var compensation_amount_minimal = document.querySelector('.compensation_amount_minimal');
-
-                      if(qtyVal > 1)
-                      {
-
-                         cad_minimal.style.fontSize = 15 - qtyVal+'px';
-                        // cad_minimal.style.marginTop = 9 + qtyVal+'px';
-                         make_minimal.style.fontSize = 18 - qtyVal+'px';
-                         co2ok_logo_minimal.style.width = 52 - qtyVal+'px';
-                         comp_amount_label_minimal.style.marginLeft = -(10 + compensation_amount_minimal.textContent.length) - qtyVal +'px';
-
-                      }else{
-
-                        cad_minimal.style.fontSize = '18px';
-                      //  cad_minimal.style.marginTop = '12px';
-                        make_minimal.style.fontSize = '21px';
-                        co2ok_logo_minimal.style.width = '55px';
-                        comp_amount_label_minimal.style.marginLeft = '-3px';
-
-                      }
-
-                    }
-
-
                     function checkoutButton()
                     {
-
-                      var productQuantity = document.querySelector('.product-quantity');
+                      console.log("checkoutButton");
                       var comp_amount_label_minimal = document.querySelector('.comp_amount_label_minimal');
-                      var productQuantityLength = productQuantity.textContent.length - 2;
+                      // var productQuantityLength = productQuantity.textContent.length - 2;
                       var compensation_amount_minimal = document.querySelector('.compensation_amount_minimal');
 
                         var compensationAmountLength = compensation_amount_global.textContent.length;
+                        console.log(compensation_amount_global.textContent, compensationAmountLength);
                         if(co2ok_temp_global.id == 'default_co2ok_temp')
                         {
 
-                            if(productQuantityLength > 1)
-                            {
-
-                              cad.style.fontSize = 18 - productQuantityLength +'px';
-                              cad.style.marginTop = 12 + productQuantityLength +'px';
-                              make.style.fontSize = 21 - productQuantityLength +'px';
-                              co2ok_logo.style.width = 55 - productQuantityLength +'px';
-
-                            }else{
-
-                              cad.style.fontSize = '16px';
-                              make.style.fontSize = '18px';
-                              co2ok_logo.style.width = '55px';
-
-                            }
-
+                          if(compensationAmountLength > 7){
+                            cad.style.fontSize = 16 - compensationAmountLength / 2.5 +'px';
+                            cad.style.marginTop = 10 + compensationAmountLength / 2.5 +'px';
+                            make.style.fontSize = 18 - compensationAmountLength / 2.5 +'px';
+                            co2ok_logo.style.width = 55 - compensationAmountLength / 2.5 +'px';
+                          }else{
+                            cad.style.fontSize = '16px';
+                            cad.style.marginTop= '9px';
+                            make.style.fontSize = '18px';
+                            co2ok_logo.style.width = '55px';
+                          }
                         }else{
+                          if(compensationAmountLength > 7){
+                            cad_minimal.style.fontSize = 18 - (compensationAmountLength - 3)+'px';
+                            make_minimal.style.fontSize = 21 - (compensationAmountLength - 3)+'px';
+                            co2ok_logo_minimal.style.width = 55 - (compensationAmountLength - 3)+'px';
+                            comp_amount_label_minimal.style.marginLeft = -(10 + compensation_amount_minimal.textContent.length) - compensationAmountLength +'px';
+                          }else{
 
-                            if(compensationAmountLength > 8)
-                            {
-
-                              cad_minimal.style.fontSize = 18 - (compensationAmountLength - 3)+'px';
-                              make_minimal.style.fontSize = 21 - (compensationAmountLength - 3)+'px';
-                              co2ok_logo_minimal.style.width = 55 - (compensationAmountLength - 3)+'px';
-                              comp_amount_label_minimal.style.marginLeft = -(10 + compensation_amount_minimal.textContent.length) - compensationAmountLength +'px';
-
-                            }else{
-
-                              cad_minimal.style.fontSize = '18px';
-                              make_minimal.style.fontSize = '21px';
-                              co2ok_logo_minimal.style.width = '55px';
-                              comp_amount_label_minimal.style.marginLeft = '-3px';
-
-                            }
-
+                            cad_minimal.style.fontSize = '18px';
+                            make_minimal.style.fontSize = '21px';
+                            co2ok_logo_minimal.style.width = '55px';
+                            comp_amount_label_minimal.style.marginLeft = '-3px';
+                          }
                         }
-
                     }
                 }
 

--- a/js/co2ok-plugin.js
+++ b/js/co2ok-plugin.js
@@ -7,7 +7,6 @@ function minimumButton() {
   var make_minimal = document.querySelector('.make_co2ok_global');
   var co2ok_logo_minimal = document.querySelector('.co2ok_logo_minimal');
   var comp_amount_label_minimal = document.querySelector('.comp_amount_label_minimal');
-  var compensation_amount_minimal = document.querySelector('.compensation_amount_minimal');
   var co2ok_info_hitare_minimal = document.querySelector('.co2ok_payoff_minimal');
   var inner_border_minimal = document.querySelector('.inner_comp_amount_label_minimal');
 
@@ -31,13 +30,12 @@ function minimumButton() {
     cad_minimal.style.fontSize = relative_font_size - relative_size_diff + 'px';
     make_minimal.style.fontSize = relative_font_size - relative_size_diff + 3 + 'px';
     co2ok_logo_minimal.style.width = 45 - relative_size_diff + 'px';
-    comp_amount_label_minimal.style.marginLeft = -(10 + compensation_amount_minimal.textContent.length) - cad_length_minimal +'px';
+    comp_amount_label_minimal.style.marginLeft = -(10 + (cad_length_minimal * 2)) + 'px';
+    comp_amount_label_minimal.style.marginTop = '-4px';
     comp_amount_label_minimal.style.width = 70 + cad_length_minimal + 'px';
     inner_border_minimal.style.width = 65 + cad_length_minimal + 'px';
-    comp_amount_label_minimal.style.marginTop = '-4px';
     co2ok_info_hitare_minimal.style.paddingLeft = cad_length_minimal * 2 + 'px';
     co2ok_info_hitare_minimal.style.marginTop = '-3px';
-
 
   }
 }

--- a/js/co2ok-plugin.js
+++ b/js/co2ok-plugin.js
@@ -32,7 +32,7 @@ function minimumButton() {
   if (cad_length_minimal > 7) {
 
     cad_minimal.style.fontSize = relative_font_size - relative_size_diff + 'px';
-    make_minimal.style.fontSize = relative_font_size - relative_size_diff + 'px';
+    make_minimal.style.fontSize = relative_font_size - relative_size_diff + 3 + 'px';
     cad_minimal.style.marginTop = '0px';
     co2ok_logo_minimal.style.width = 45 - relative_size_diff + 'px';
     comp_amount_label_minimal.style.marginLeft = -(10 + compensation_amount_minimal.textContent.length) - cad_length_minimal +'px';
@@ -83,7 +83,7 @@ function defaultButton() {
 
     cad.style.fontSize = relative_font_size - relative_size_diff + 'px';
     cad.style.left = '-20px';
-    make.style.fontSize = relative_font_size - relative_size_diff + 'px';
+    make.style.fontSize = relative_font_size - relative_size_diff + 1 + 'px';
     co2ok_logo.style.width = 45 - relative_size_diff + 'px';
 
   } else {


### PR DESCRIPTION
Size of font and logo are relative to the length of the compensation now. Did a little refactor of the code->removed duplicate code, cart and checkout button go to same function minimal and default button functions successfully as compensations string is being used rather than quantity of items, and made consistency changes 

Tested in all themes in WC-test.co2ok.eco

**Sample Result:**

<img width="660" alt="Screen Shot 2020-10-20 at 1 02 39 PM" src="https://user-images.githubusercontent.com/45078521/96577954-bc82fd80-12d4-11eb-9622-1aa2819217be.png">
<img width="676" alt="Screen Shot 2020-10-20 at 1 02 45 PM" src="https://user-images.githubusercontent.com/45078521/96577961-be4cc100-12d4-11eb-9486-dd692739c629.png">

<img width="660" alt="Screen Shot 2020-10-20 at 12 57 58 PM" src="https://user-images.githubusercontent.com/45078521/96578073-e63c2480-12d4-11eb-84ba-51acc317093a.png">
<img width="538" alt="Screen Shot 2020-10-20 at 12 58 04 PM" src="https://user-images.githubusercontent.com/45078521/96578076-e89e7e80-12d4-11eb-9ef2-1f221c6de915.png">
<img width="677" alt="Screen Shot 2020-10-20 at 12 57 50 PM" src="https://user-images.githubusercontent.com/45078521/96578077-e9371500-12d4-11eb-9723-517a4f32c6a8.png">
<img width="682" alt="Screen Shot 2020-10-20 at 12 57 43 PM" src="https://user-images.githubusercontent.com/45078521/96578081-e9cfab80-12d4-11eb-8c3a-33cf88a1277b.png">
<img width="638" alt="Screen Shot 2020-10-20 at 12 58 41 PM" src="https://user-images.githubusercontent.com/45078521/96578083-e9cfab80-12d4-11eb-911d-dfeea161554e.png">
<img width="663" alt="Screen Shot 2020-10-20 at 12 58 47 PM" src="https://user-images.githubusercontent.com/45078521/96578085-ea684200-12d4-11eb-8a84-9ec6d106a337.png">




**Discrepancies found for two themes:** 

Woodmart: 
minimal: 
<img width="436" alt="Screen Shot 2020-10-20 at 12 25 13 PM" src="https://user-images.githubusercontent.com/45078521/96574986-775ccc80-12d0-11eb-9eb1-411b6a5a2544.png">
default:
<img width="261" alt="Screen Shot 2020-10-20 at 12 30 08 PM" src="https://user-images.githubusercontent.com/45078521/96575012-7e83da80-12d0-11eb-8f47-bdd487ec19a1.png">


27:
default:
<img width="305" alt="Screen Shot 2020-10-20 at 11 31 25 AM" src="https://user-images.githubusercontent.com/45078521/96575023-82176180-12d0-11eb-861f-e952a4cc4c6c.png">
