### PR TITLE
mijnkraamshop css overwritting co2ok button

### DIFF
--- a/css/co2ok.css
+++ b/css/co2ok.css
@@ -138,6 +138,8 @@
       border-radius: 12px; }
     .co2ok_container .co2ok_checkbox_container #checkbox_label a {
        border-radius: 12px;
+       letter-spacing: 0px;
+       text-align: inherit;
     }
     .co2ok_container .co2ok_checkbox_container .inner_checkbox_label {
       position: relative;

--- a/js/co2ok-plugin.js
+++ b/js/co2ok-plugin.js
@@ -12,7 +12,7 @@ function minimumButton() {
 
   var cad_length_minimal = cad_minimal.innerHTML.length;
 
-  //removes any white spaces in compensataion amount
+  //removes spaces in compensataion amount
   cad_minimal = cad_minimal.innerHTML.replace(/\s+/g, '');
 
   //changes style relative to length of compensation
@@ -50,7 +50,7 @@ function defaultButton() {
   var co2ok_logo = document.querySelector('.co2ok_logo_default');
   var cad_length = cad.innerHTML.length;
 
-  //removes white spaces from compensataion amount
+  //removes spaces from compensataion amount
   cad = cad.innerHTML.replace(/\s+/g, '');
 
   //changes style relative to length of compensation

--- a/js/co2ok-plugin.js
+++ b/js/co2ok-plugin.js
@@ -12,6 +12,9 @@ function minimumButton() {
 
   var cad_length_minimal = cad_minimal.innerHTML.length;
 
+  //removes any white spaces in compensataion amount
+  cad_minimal = cad_minimal.innerHTML.replace(/\s+/g, '');
+
   //changes style relative to length of compensation
   if (cad_length_minimal > 10) {
 
@@ -46,6 +49,9 @@ function defaultButton() {
   var cad = document.querySelector('.compensation_amount_default');
   var co2ok_logo = document.querySelector('.co2ok_logo_default');
   var cad_length = cad.innerHTML.length;
+
+  //removes white spaces from compensataion amount
+  cad = cad.innerHTML.replace(/\s+/g, '');
 
   //changes style relative to length of compensation
   if (cad_length > 10) {


### PR DESCRIPTION
mijnkraamshop css has letter-spacing and and text-align that altered the layout of our button. Added two lines of css to counteract these theme settings. 

Also found in chrome, their site added spaces around + and € in compensation amount. This was an added spaces issue with the button layout in chrome. To counteract this, a single line of javascript was added to remove spaces in compensation amount.

These changes were tested in wooCommerce


Chrome: Before and After

<img width="302" alt="Screen Shot 2020-10-27 at 12 38 53 PM" src="https://user-images.githubusercontent.com/45078521/97297615-8dc7d280-1852-11eb-882d-e373587f21f9.png">
<img width="282" alt="Screen Shot 2020-10-27 at 12 41 27 PM" src="https://user-images.githubusercontent.com/45078521/97297623-915b5980-1852-11eb-9cc2-b45ab8680f55.png">


Firefox: Before and After
<img width="290" alt="Screen Shot 2020-10-27 at 12 41 58 PM" src="https://user-images.githubusercontent.com/45078521/97297659-9cae8500-1852-11eb-854f-164180393161.png">
<img width="286" alt="Screen Shot 2020-10-27 at 12 41 46 PM" src="https://user-images.githubusercontent.com/45078521/97297664-9d471b80-1852-11eb-940c-9ae40cfedab4.png">
